### PR TITLE
Remove Transfer Overflow Checks

### DIFF
--- a/contracts/l2/dai.sol
+++ b/contracts/l2/dai.sol
@@ -93,7 +93,7 @@ contract Dai {
 
   // --- ERC20 Mutations ---
   function transfer(address to, uint256 value) external returns (bool) {
-    require(to != address(0), "Dai/invalid-address");
+    require(to != address(0) && to != address(this), "Dai/invalid-address");
     uint256 balance = balanceOf[msg.sender];
     require(balance >= value, "Dai/insufficient-balance");
 
@@ -105,7 +105,7 @@ contract Dai {
     return true;
   }
   function transferFrom(address from, address to, uint256 value) external returns (bool) {
-    require(to != address(0), "Dai/invalid-address");
+    require(to != address(0) && to != address(this), "Dai/invalid-address");
     uint256 balance = balanceOf[from];
     require(balance >= value, "Dai/insufficient-balance");
 
@@ -153,7 +153,7 @@ contract Dai {
   
   // --- Mint/Burn ---
   function mint(address to, uint256 value) external auth {
-    require(to != address(0), "Dai/invalid-address");
+    require(to != address(0) && to != address(this), "Dai/invalid-address");
     balanceOf[to] = add(balanceOf[to], value);
     totalSupply   = add(totalSupply, value);
 

--- a/contracts/l2/dai.sol
+++ b/contracts/l2/dai.sol
@@ -98,7 +98,7 @@ contract Dai {
     require(balance >= value, "Dai/insufficient-balance");
 
     balanceOf[msg.sender] = balance - value;
-    balanceOf[to] = balanceOf[to] + value;
+    balanceOf[to] += value;
 
     emit Transfer(msg.sender, to, value);
 
@@ -119,7 +119,7 @@ contract Dai {
     }
 
     balanceOf[from] = balance - value;
-    balanceOf[to] = balanceOf[to] + value;
+    balanceOf[to] += value;
 
     emit Transfer(from, to, value);
 

--- a/contracts/l2/dai.sol
+++ b/contracts/l2/dai.sol
@@ -72,9 +72,6 @@ contract Dai {
     assembly {chainId := chainid()}
     deploymentChainId = chainId;
     _DOMAIN_SEPARATOR = _calculateDomainSeparator(chainId);
-
-    // Set addresses which disallow transfer
-    balanceOf[address(this)] = balanceOf[address(0)] = type(uint256).max;
   }
 
   function _calculateDomainSeparator(uint256 chainId) private view returns (bytes32) {
@@ -96,17 +93,19 @@ contract Dai {
 
   // --- ERC20 Mutations ---
   function transfer(address to, uint256 value) external returns (bool) {
+    require(to != address(0), "Dai/invalid-address");
     uint256 balance = balanceOf[msg.sender];
     require(balance >= value, "Dai/insufficient-balance");
 
     balanceOf[msg.sender] = balance - value;
-    balanceOf[to] = add(balanceOf[to], value);
+    balanceOf[to] = balanceOf[to] + value;
 
     emit Transfer(msg.sender, to, value);
 
     return true;
   }
   function transferFrom(address from, address to, uint256 value) external returns (bool) {
+    require(to != address(0), "Dai/invalid-address");
     uint256 balance = balanceOf[from];
     require(balance >= value, "Dai/insufficient-balance");
 
@@ -120,7 +119,7 @@ contract Dai {
     }
 
     balanceOf[from] = balance - value;
-    balanceOf[to] = add(balanceOf[to], value);
+    balanceOf[to] = balanceOf[to] + value;
 
     emit Transfer(from, to, value);
 
@@ -154,6 +153,7 @@ contract Dai {
   
   // --- Mint/Burn ---
   function mint(address to, uint256 value) external auth {
+    require(to != address(0), "Dai/invalid-address");
     balanceOf[to] = add(balanceOf[to], value);
     totalSupply   = add(totalSupply, value);
 

--- a/test/l2/dai.ts
+++ b/test/l2/dai.ts
@@ -78,29 +78,29 @@ describe('Dai', () => {
       })
 
       it('should not transfer to zero address', async () => {
-        await expect(dai.connect(signers.user1).transfer(ethers.constants.AddressZero, 1)).to.be.revertedWith('')
+        await expect(dai.connect(signers.user1).transfer(ethers.constants.AddressZero, 1)).to.be.revertedWith('Dai/invalid-address')
         await expect(
           dai.connect(signers.user1).transferFrom(signers.user1.address, ethers.constants.AddressZero, 1),
-        ).to.be.revertedWith('')
+        ).to.be.revertedWith('Dai/invalid-address')
       })
 
       it('should not transfer to dai address', async () => {
-        await expect(dai.connect(signers.user1).transfer(dai.address, 1)).to.be.revertedWith('')
+        await expect(dai.connect(signers.user1).transfer(dai.address, 1)).to.be.revertedWith('Dai/invalid-address')
         await expect(dai.connect(signers.user1).transferFrom(signers.user1.address, dai.address, 1)).to.be.revertedWith(
-          '',
+          'Dai/invalid-address',
         )
       })
 
       it('should not allow minting to zero address', async () => {
-        await expect(dai.mint(ethers.constants.AddressZero, 1)).to.be.revertedWith('')
+        await expect(dai.mint(ethers.constants.AddressZero, 1)).to.be.revertedWith('Dai/invalid-address')
       })
 
       it('should not allow minting to dai address', async () => {
-        await expect(dai.mint(dai.address, 1)).to.be.revertedWith('')
+        await expect(dai.mint(dai.address, 1)).to.be.revertedWith('Dai/invalid-address')
       })
 
       it('should not allow minting to address beyond MAX', async () => {
-        await expect(dai.mint(signers.user1.address, ethers.constants.MaxUint256)).to.be.revertedWith('')
+        await expect(dai.mint(signers.user1.address, ethers.constants.MaxUint256)).to.be.reverted
       })
 
       it('burns own dai', async () => {
@@ -250,7 +250,7 @@ describe('Dai', () => {
         it('should not increaseAllowance beyond MAX', async () => {
           await expect(
             dai.connect(signers.user1).increaseAllowance(signers.user2.address, ethers.constants.MaxUint256),
-          ).to.be.revertedWith('')
+          ).to.be.reverted
         })
 
         it('decreaseAllowance should decrease allowance', async () => {

--- a/test/l2/dai.ts
+++ b/test/l2/dai.ts
@@ -84,19 +84,8 @@ describe('Dai', () => {
         ).to.be.revertedWith('')
       })
 
-      it('should not transfer to dai address', async () => {
-        await expect(dai.connect(signers.user1).transfer(dai.address, 1)).to.be.revertedWith('')
-        await expect(dai.connect(signers.user1).transferFrom(signers.user1.address, dai.address, 1)).to.be.revertedWith(
-          '',
-        )
-      })
-
       it('should not allow minting to zero address', async () => {
         await expect(dai.mint(ethers.constants.AddressZero, 1)).to.be.revertedWith('')
-      })
-
-      it('should not allow minting to dai address', async () => {
-        await expect(dai.mint(dai.address, 1)).to.be.revertedWith('')
       })
 
       it('should not allow minting to address beyond MAX', async () => {

--- a/test/l2/dai.ts
+++ b/test/l2/dai.ts
@@ -78,7 +78,9 @@ describe('Dai', () => {
       })
 
       it('should not transfer to zero address', async () => {
-        await expect(dai.connect(signers.user1).transfer(ethers.constants.AddressZero, 1)).to.be.revertedWith('Dai/invalid-address')
+        await expect(dai.connect(signers.user1).transfer(ethers.constants.AddressZero, 1)).to.be.revertedWith(
+          'Dai/invalid-address',
+        )
         await expect(
           dai.connect(signers.user1).transferFrom(signers.user1.address, ethers.constants.AddressZero, 1),
         ).to.be.revertedWith('Dai/invalid-address')
@@ -248,9 +250,8 @@ describe('Dai', () => {
         })
 
         it('should not increaseAllowance beyond MAX', async () => {
-          await expect(
-            dai.connect(signers.user1).increaseAllowance(signers.user2.address, ethers.constants.MaxUint256),
-          ).to.be.reverted
+          await expect(dai.connect(signers.user1).increaseAllowance(signers.user2.address, ethers.constants.MaxUint256))
+            .to.be.reverted
         })
 
         it('decreaseAllowance should decrease allowance', async () => {

--- a/test/l2/dai.ts
+++ b/test/l2/dai.ts
@@ -84,8 +84,19 @@ describe('Dai', () => {
         ).to.be.revertedWith('')
       })
 
+      it('should not transfer to dai address', async () => {
+        await expect(dai.connect(signers.user1).transfer(dai.address, 1)).to.be.revertedWith('')
+        await expect(dai.connect(signers.user1).transferFrom(signers.user1.address, dai.address, 1)).to.be.revertedWith(
+          '',
+        )
+      })
+
       it('should not allow minting to zero address', async () => {
         await expect(dai.mint(ethers.constants.AddressZero, 1)).to.be.revertedWith('')
+      })
+
+      it('should not allow minting to dai address', async () => {
+        await expect(dai.mint(dai.address, 1)).to.be.revertedWith('')
       })
 
       it('should not allow minting to address beyond MAX', async () => {


### PR DESCRIPTION
Overflow checks are not necessary as the amount of DAI being transferred is bounded by the user balances which is well below 2^256 during normal operation. In the event the `mint` is compromised all bets are off anyways.

This still needs discussion as to whether to `to` should be also checked to not equal the token address.